### PR TITLE
Do not omit parens for selected 0/1-arity function calls

### DIFF
--- a/lib/ex_format.ex
+++ b/lib/ex_format.ex
@@ -155,6 +155,8 @@ defmodule ExFormat do
       {sym, meta1, [{fun, meta2, nil} | rest]} when
           sym in [:def, :defp, :defmacro, :defmacrop, :defdelegate] ->
         {sym, meta1, [{fun, meta2, []} | rest]}
+      {:|>, meta1, [left, {fun, meta2, nil}]} ->
+        {:|>, meta1, [left, {fun, meta2, []}]}
       _ ->
         ast
     end

--- a/test/unit/fun_parens_test.exs
+++ b/test/unit/fun_parens_test.exs
@@ -57,4 +57,26 @@ defmodule ExFormat.Unit.FunParensTest do
       assert_format_string(bad, good)
     end
   end
+
+  describe "do not omit parentheses" do
+    test "for remote zero-arity function calls" do
+      assert_format_string("Mix.env", "Mix.env()\n")
+    end
+
+    test "for one-arity function calls in pipelines" do
+      bad = """
+      input
+      |> String.strip
+      |> decode
+      """
+      good = """
+      input
+      |> String.strip()
+      |> decode()
+      """
+      assert_format_string(bad, good)
+
+      assert_format_string("input |> fun1 |> fun2", "input |> fun1() |> fun2()\n")
+    end
+  end
 end


### PR DESCRIPTION
- Remote 0-arity function calls (already implemented, just adding tests in this PR)
- 1-arity function calls in pipelines