### PR TITLE
Enforce keyword syntax for tuples of size 2 inside list

### DIFF
--- a/lib/ex_format.ex
+++ b/lib/ex_format.ex
@@ -75,6 +75,7 @@ defmodule ExFormat do
     state = %{
       parenless_calls: MapSet.new(@parenless_calls),
       parenless_zero_arity?: false,
+      inside_list?: false,
       in_spec: nil,
     }
     for {line, i} <- Enum.with_index(lines) do
@@ -428,10 +429,9 @@ defmodule ExFormat do
 
   # Tuple containers
   def to_string({:{}, _, args} = ast, fun, state) do
-    inside_list? = Map.get(state, :inside_list?)
     tuple =
       # Enforce keyword syntax for tuples of size 2 inside list
-      if inside_list? == true and length(args) == 2 do
+      if state.inside_list? and length(args) == 2 do
         [k, v] = args
         kw_list_to_string([{k, v}], fun, state)
       else
@@ -980,7 +980,7 @@ defmodule ExFormat do
   end
 
   defp list_to_string(list, fun, state) do
-    state = Map.put(state, :inside_list?, true)
+    state = %{state | inside_list?: true}
     list_string = Enum.map_join(list, ", ", &to_string(&1, fun, state))
     if not fits?("  " <> list_string <> "  ") or line_breaks?(list) do
       list_to_multiline_string(list, fun, state)

--- a/lib/ex_format.ex
+++ b/lib/ex_format.ex
@@ -75,7 +75,7 @@ defmodule ExFormat do
     state = %{
       parenless_calls: MapSet.new(@parenless_calls),
       parenless_zero_arity?: false,
-      inside_list?: false,
+      in_list?: false,
       in_spec: nil,
     }
     for {line, i} <- Enum.with_index(lines) do
@@ -431,7 +431,7 @@ defmodule ExFormat do
   def to_string({:{}, _, args} = ast, fun, state) do
     tuple =
       # Enforce keyword syntax for tuples of size 2 inside list
-      if state.inside_list? and length(args) == 2 do
+      if state.in_list? and length(args) == 2 do
         [k, v] = args
         kw_list_to_string([{k, v}], fun, state)
       else
@@ -980,7 +980,7 @@ defmodule ExFormat do
   end
 
   defp list_to_string(list, fun, state) do
-    state = %{state | inside_list?: true}
+    state = %{state | in_list?: true}
     list_string = Enum.map_join(list, ", ", &to_string(&1, fun, state))
     if not fits?("  " <> list_string <> "  ") or line_breaks?(list) do
       list_to_multiline_string(list, fun, state)

--- a/test/unit/indentation_test.exs
+++ b/test/unit/indentation_test.exs
@@ -67,10 +67,9 @@ defmodule ExFormat.Unit.IndentationTest do
       [{:prefix_newline, get_prefix_newline(curr_lineno-1, prev_lineno)}] ++ curr_ctx
       """
       good = """
-      [{:prev, prev_lineno}] ++
-      [{:prefix_comments, get_prefix_comments(curr_lineno - 1, prev_lineno)}] ++
-      [{:prefix_newline, get_prefix_newline(curr_lineno - 1, prev_lineno)}] ++
-      curr_ctx
+      [prev: prev_lineno] ++
+      [prefix_comments: get_prefix_comments(curr_lineno - 1, prev_lineno)] ++
+      [prefix_newline: get_prefix_newline(curr_lineno - 1, prev_lineno)] ++ curr_ctx
       """
       assert_format_string(bad, good)
     end

--- a/test/unit/kw_list_syntax_test.exs
+++ b/test/unit/kw_list_syntax_test.exs
@@ -44,4 +44,20 @@ defmodule ExFormat.Unit.KwListSyntaxTest do
       """
     end
   end
+
+  describe "keyword syntax for tuples inside list" do
+    test "maintain keyword sugar for tuples of size 2" do
+      assert_format_string("[:foo, bar: :baz]\n")
+      assert_format_string("[bar: :baz]\n")
+    end
+
+    test "enforce keyword sugar for tuples of size 2" do
+      assert_format_string("[{:bar, :baz}]", "[bar: :baz]\n")
+      assert_format_string("[:foo, {:bar, :baz}]", "[:foo, bar: :baz]\n")
+    end
+
+    test "do not enforce keyword sugar for tuples of size more than 2" do
+      assert_format_string("[{:foo, :bar, :baz}]\n")
+    end
+  end
 end

--- a/test/unit/kw_list_test.exs
+++ b/test/unit/kw_list_test.exs
@@ -147,7 +147,7 @@ defmodule ExFormat.Unit.KeywordListTest do
           package: package(),
           aliases: aliases(),
           test_coverage: [tool: ExCoveralls],
-          preferred_cli_env: [{:"test.local", :test}, {:coveralls, :test}, {:"coveralls.travis", :test}],
+          preferred_cli_env: ["test.local": :test, coveralls: :test, "coveralls.travis": :test],
           name: "Mssqlex",
           source_url: "https://github.com/findmypast-oss/mssqlex",
           docs: [main: "readme", extras: ["README.md"]],

--- a/test/unit/list_test.exs
+++ b/test/unit/list_test.exs
@@ -92,13 +92,13 @@ defmodule ExFormat.Unit.ListTest do
       defp deps() do
         [
           # Web server
-          {:cowboy, "~> 1.0"},
+          cowboy: "~> 1.0",
           # Web framework
-          {:phoenix, "~> 1.3.0-rc"},
+          phoenix: "~> 1.3.0-rc",
           # XML parser helper
-          {:sweet_xml, "~> 0.6"},
+          sweet_xml: "~> 0.6",
           # Statsd metrics sink client
-          {:statix, "~> 1.0"},
+          statix: "~> 1.0",
         ]
       end
       """


### PR DESCRIPTION
This fixes issue https://github.com/uohzxela/ex_format/issues/44. As discussed, issue https://github.com/uohzxela/ex_format/issues/49 is a related problem but requires a different solution, so I will open a separate PR for that.