### PR TITLE
Indent for selected multiline binary operators

### DIFF
--- a/test/unit/indentation_test.exs
+++ b/test/unit/indentation_test.exs
@@ -64,8 +64,8 @@ defmodule ExFormat.Unit.IndentationTest do
       """
       good = """
       "In the first hours of day" <>
-      "consciousness can embrace the world" <>
-      "just as the hand grasps a sun-warm stone."
+        "consciousness can embrace the world" <>
+        "just as the hand grasps a sun-warm stone."
       """
       assert_format_string(bad, good)
     end
@@ -78,8 +78,8 @@ defmodule ExFormat.Unit.IndentationTest do
       """
       good = """
       "The traveler stands under the tree. After" <>
-      "the plunge through" <> # death's whirling vortex, will
-      "a great light" # unfurl over his head?
+        "the plunge through" <> # death's whirling vortex, will
+        "a great light" # unfurl over his head?
       """
       assert_format_string(bad, good)
 
@@ -90,9 +90,46 @@ defmodule ExFormat.Unit.IndentationTest do
       """
       good = """
       [{:prev, prev_lineno}] ++
-      [{:prefix_comments, get_prefix_comments(curr_lineno - 1, prev_lineno)}] ++
-      [{:prefix_newline, get_prefix_newline(curr_lineno - 1, prev_lineno)}] ++
-      curr_ctx
+        [{:prefix_comments, get_prefix_comments(curr_lineno - 1, prev_lineno)}] ++
+        [{:prefix_newline, get_prefix_newline(curr_lineno - 1, prev_lineno)}] ++
+        curr_ctx
+      """
+      assert_format_string(bad, good)
+    end
+
+    test "correct indentation of multiline binary op" do
+      bad = """
+      "No matching message.\\n" <>
+      "Process mailbox:\\n" <>
+      mailbox
+      """
+      good = """
+      "No matching message.\\n" <>
+        "Process mailbox:\\n" <>
+        mailbox
+      """
+      assert_format_string(bad, good)
+
+      assert_format_string """
+
+      "No matching message.\\n" <>
+        "Process mailbox:\\n" <>
+        mailbox
+      """
+    end
+
+    test "correct indentation of binary op when assigning" do
+      bad = """
+      message =
+        "No matching message.\\n" <>
+          "Process mailbox:\\n" <>
+          mailbox
+      """
+      good = """
+      message =
+        "No matching message.\\n" <>
+        "Process mailbox:\\n" <>
+        mailbox
       """
       assert_format_string(bad, good)
     end


### PR DESCRIPTION
For issue: https://github.com/uohzxela/ex_format/issues/40

This only works for `<>`, `++`, `and`, `or` operators. Let me know if I should include more.

Also, just wondering - do we need to split every operand on each line (similar to issue https://github.com/uohzxela/ex_format/issues/20) if we detect a line break in the binary op expression? If yes, I'll start a new PR for that.