### PR TITLE
Split call args on each line if they are too long

### DIFF
--- a/lib/ex_format.ex
+++ b/lib/ex_format.ex
@@ -980,7 +980,7 @@ defmodule ExFormat do
     target_string = call_to_string(target, fun, state)
     args_string = args_to_string(args, fun, state)
     args_string =
-      if not fits?(args_string) do
+      if not fits?(args_string) or line_breaks?(args) do
         delimiter = ",\n#{String.duplicate(" ", String.length(target_string) + 1)}"
         args_to_string(args, fun, delimiter, state)
       else

--- a/lib/ex_format.ex
+++ b/lib/ex_format.ex
@@ -981,7 +981,8 @@ defmodule ExFormat do
     args_string = args_to_string(args, fun, state)
     args_string =
       if not fits?(args_string) do
-        args_to_string(args, fun, ",\n  ", state)
+        delimiter = ",\n#{String.duplicate(" ", String.length(target_string) + 1)}"
+        args_to_string(args, fun, delimiter, state)
       else
         args_string
       end

--- a/lib/ex_format.ex
+++ b/lib/ex_format.ex
@@ -979,6 +979,12 @@ defmodule ExFormat do
   defp call_to_string_with_args(target, args, fun, state) do
     target_string = call_to_string(target, fun, state)
     args_string = args_to_string(args, fun, state)
+    args_string =
+      if not fits?(args_string) do
+        args_to_string(args, fun, ",\n  ", state)
+      else
+        args_string
+      end
     if parenless_call?(target, args, state) do
       target_string <> " " <> args_string |> String.trim()
     else

--- a/test/unit/fun_args_test.exs
+++ b/test/unit/fun_args_test.exs
@@ -1,0 +1,14 @@
+defmodule ExFormat.Unit.FunArgsTest do
+  import Test.Support.Unit
+  use ExUnit.Case
+
+  test "split args if they are too long for function calls" do
+    bad = "Enum.map_join(some_very_long_function_name1(args), some_very_long_function_name2(delimiter), &to_string(&1, fun, state))"
+    good = """
+    Enum.map_join(some_very_long_function_name1(args),
+      some_very_long_function_name2(delimiter),
+      &to_string(&1, fun, state))
+    """
+    assert_format_string(bad, good)
+  end
+end

--- a/test/unit/fun_args_test.exs
+++ b/test/unit/fun_args_test.exs
@@ -2,7 +2,7 @@ defmodule ExFormat.Unit.FunArgsTest do
   import Test.Support.Unit
   use ExUnit.Case
 
-  describe "split args if they are too long for function calls" do
+  describe "split function call args if they are too long" do
     test "with remote calls" do
       bad = "Enum.map_join(some_very_long_function_name1(args), some_very_long_function_name2(delimiter), &to_string(&1, fun, state))"
       good = """
@@ -18,6 +18,34 @@ defmodule ExFormat.Unit.FunArgsTest do
       good = """
       local_call(some_very_long_function_name1(args),
                  some_very_long_function_name2(delimiter),
+                 &to_string(&1, fun, state))
+      """
+      assert_format_string(bad, good)
+    end
+  end
+
+  describe "split function call args if they have intended line break" do
+    test "with remote calls" do
+      bad = """
+      Enum.map_join(args,
+        delimiter, &to_string(&1, fun, state))
+      """
+      good = """
+      Enum.map_join(args,
+                    delimiter,
+                    &to_string(&1, fun, state))
+      """
+      assert_format_string(bad, good)
+    end
+
+    test "with local calls" do
+      bad = """
+      local_call(args, delimiter,
+        &to_string(&1, fun, state))
+      """
+      good = """
+      local_call(args,
+                 delimiter,
                  &to_string(&1, fun, state))
       """
       assert_format_string(bad, good)

--- a/test/unit/fun_args_test.exs
+++ b/test/unit/fun_args_test.exs
@@ -2,13 +2,25 @@ defmodule ExFormat.Unit.FunArgsTest do
   import Test.Support.Unit
   use ExUnit.Case
 
-  test "split args if they are too long for function calls" do
-    bad = "Enum.map_join(some_very_long_function_name1(args), some_very_long_function_name2(delimiter), &to_string(&1, fun, state))"
-    good = """
-    Enum.map_join(some_very_long_function_name1(args),
-      some_very_long_function_name2(delimiter),
-      &to_string(&1, fun, state))
-    """
-    assert_format_string(bad, good)
+  describe "split args if they are too long for function calls" do
+    test "with remote calls" do
+      bad = "Enum.map_join(some_very_long_function_name1(args), some_very_long_function_name2(delimiter), &to_string(&1, fun, state))"
+      good = """
+      Enum.map_join(some_very_long_function_name1(args),
+                    some_very_long_function_name2(delimiter),
+                    &to_string(&1, fun, state))
+      """
+      assert_format_string(bad, good)
+    end
+
+    test "with local calls" do
+      bad = "local_call(some_very_long_function_name1(args), some_very_long_function_name2(delimiter), &to_string(&1, fun, state))"
+      good = """
+      local_call(some_very_long_function_name1(args),
+                 some_very_long_function_name2(delimiter),
+                 &to_string(&1, fun, state))
+      """
+      assert_format_string(bad, good)
+    end
   end
 end


### PR DESCRIPTION
I don't recall discussing how should we split call args, but here's what the formatter can do so far:

`Enum.map_join(some_very_long_function_name1(args), some_very_long_function_name2(delimiter), &to_string(&1, fun, state))`

to

```
Enum.map_join(some_very_long_function_name1(args),
  some_very_long_function_name2(delimiter),
  &to_string(&1, fun, state))
```

Wdyt? @whatyouhide 